### PR TITLE
Resolved bug causing file uploads not disabling inside of agents endpoint

### DIFF
--- a/client/src/components/Chat/Input/Files/AttachFileChat.tsx
+++ b/client/src/components/Chat/Input/Files/AttachFileChat.tsx
@@ -30,7 +30,7 @@ function AttachFileChat({ disableInputs }: { disableInputs: boolean }) {
 
   if (isAssistants && endpointSupportsFiles && !isUploadDisabled) {
     return <AttachFile disabled={disableInputs} />;
-  } else if (isAgents || (endpointSupportsFiles && !isUploadDisabled)) {
+  } else if (endpointSupportsFiles && !isUploadDisabled) {
     return (
       <AttachFileMenu
         disabled={disableInputs}


### PR DESCRIPTION
# Pull Request Template

⚠️ Before Submitting a PR, Please Review:
- Please ensure that you have thoroughly read and understood the [Contributing Docs](https://github.com/danny-avila/LibreChat/blob/main/.github/CONTRIBUTING.md) before submitting your Pull Request.

⚠️ Documentation Updates Notice:
- Kindly note that documentation updates are managed in this repository: [librechat.ai](https://github.com/LibreChat-AI/librechat.ai)

## Summary

Please provide a brief summary of your changes and the related issue. Include any motivation and context that is relevant to your changes. If there are any dependencies necessary for your changes, please list them here.

**Issue**: File upload icons (paperclip) were showing in the Agents tab even when fileConfig.endpoints.agents.disabled: true was configured in librechat.yaml. The UI should respect the disabled flag and hide file upload capabilities.

**Root Cause**: In client/src/components/Chat/Input/Files/AttachFileChat.tsx, the render logic had a special case for agents - unsure if this logic is intentional or a bug:

**Result**:
All endpoints now follow the same visibility rules for file uploads

## Change Type

Please delete any irrelevant options.

- [ X] Bug fix (non-breaking change which fixes an issue)

## Testing

Please describe your test process and include instructions so that we can reproduce your test. If there are any important variables for your testing configuration, list them here.

### **Test Configuration**:

Inside of librechat.yaml

```
  fileConfig:
    endpoints:
      agents:
        disabled: true
```

## Checklist

Please delete any irrelevant options.

- [ X] My code adheres to this project's style guidelines
- [ X] I have performed a self-review of my own code
- [ X] My changes do not introduce new warnings
