### PR TITLE
Patch to allow different paths to the .env file controlled by ENV_FILE

### DIFF
--- a/api/server/index.js
+++ b/api/server/index.js
@@ -1,4 +1,7 @@
-require('dotenv').config();
+// <Stripe> Patch to allow different paths to the .env file
+require('dotenv').config({ path: process.env.ENV_FILE || '.env' });
+// </Stripe>
+
 const fs = require('fs');
 const path = require('path');
 require('module-alias')({ base: path.resolve(__dirname, '..') });

--- a/api/server/index.js
+++ b/api/server/index.js
@@ -1,5 +1,6 @@
 // <Stripe> Patch to allow different paths to the .env file
-require('dotenv').config({ path: process.env.ENV_FILE || '.env' });
+// If process.env.ENV_FILE is unset, fallback to default behavior.
+require('dotenv').config({ path: process.env.ENV_FILE || undefined });
 // </Stripe>
 
 const fs = require('fs');

--- a/api/server/stripe/patch-fetch.js
+++ b/api/server/stripe/patch-fetch.js
@@ -15,7 +15,7 @@ function patchFetch() {
         '[Stripe:patchFetch] Successfully set global.fetch to node-fetch (ENABLE_NODE_FETCH == true)',
       );
     } else {
-      logger.info('[Stripe:patchFetch] Not patching fetch (ENABLE_NODE_FETCH != true)');
+      logger.warn('[Stripe:patchFetch] Not patching fetch (ENABLE_NODE_FETCH != true)');
     }
   } catch (error) {
     logger.error(`[Stripe:patchFetch] Failed to patch fetch: ${error.message}`);


### PR DESCRIPTION
This ended up being the simplest solution, control the path with an environment variable.

Tested with a few variations:

- `ENV_FILE=env/.env npm run backend` will load (and connect to Mongo) from `env/.env`
- `npm run backend`: falls back to loading from .env