### PR TITLE
[stripe] [security] disable image upload in UI

### DIFF
--- a/client/src/components/Nav/SettingsTabs/Account/Avatar.tsx
+++ b/client/src/components/Nav/SettingsTabs/Account/Avatar.tsx
@@ -198,17 +198,18 @@ function Avatar() {
                 {localize('com_ui_upload')}
               </Button>
             </>
-          ) : (
+          ) : 
+          (
             <div
               className="flex h-64 w-11/12 flex-col items-center justify-center rounded-lg border-2 border-dashed border-gray-300 bg-transparent dark:border-gray-600"
-              onDrop={handleDrop}
-              onDragOver={handleDragOver}
+              // <stripe> onDrop={handleDrop}
+              // onDragOver={handleDragOver} </stripe>
             >
               <FileImage className="mb-4 size-12 text-gray-400" />
               <p className="mb-2 text-center text-sm text-gray-500 dark:text-gray-400">
                 {localize('com_ui_drag_drop')}
               </p>
-              <Button variant="secondary" onClick={openFileDialog}>
+              {/* <stripe> <Button variant="secondary" onClick={openFileDialog}>
                 {localize('com_ui_select_file')}
               </Button>
               <input
@@ -217,7 +218,7 @@ function Avatar() {
                 className="hidden"
                 accept=".png, .jpg, .jpeg"
                 onChange={handleFileChange}
-              />
+              /> </stripe> */}
             </div>
           )}
         </div>

--- a/client/src/components/SidePanel/Agents/AgentAvatar.tsx
+++ b/client/src/components/SidePanel/Agents/AgentAvatar.tsx
@@ -188,7 +188,7 @@ function Avatar({
           </button>
         </Popover.Trigger>
       </div>
-      {<AvatarMenu handleFileChange={handleFileChange} />}
+      {/* <stripe> {<AvatarMenu handleFileChange={handleFileChange} />} </stripe> */}
     </Popover.Root>
   );
 }

--- a/client/src/components/SidePanel/Builder/AssistantAvatar.tsx
+++ b/client/src/components/SidePanel/Builder/AssistantAvatar.tsx
@@ -218,7 +218,7 @@ function Avatar({
           </button>
         </Popover.Trigger>
       </div>
-      {<AvatarMenu handleFileChange={handleFileChange} />}
+      {/* <stripe> {<AvatarMenu handleFileChange={handleFileChange} />} </stripe> */}
     </Popover.Root>
   );
 }


### PR DESCRIPTION
## Summary
Disable image upload in Agent Builder UI and User profile picture until we address security concerns with file/image upload
UI elements are still visible but they do not do anything

<img width="304" height="210" alt="Screenshot 2025-08-22 at 1 07 33 PM" src="https://github.com/user-attachments/assets/2f5dc7fc-e69d-4307-a219-547bf2bacc04" />

<img width="685" height="372" alt="Screenshot 2025-08-22 at 1 07 49 PM" src="https://github.com/user-attachments/assets/bdbbf8ca-2bc0-40e4-a4d6-60c652fabc50" />
