### PR TITLE
publish every push to docker hub

### DIFF
--- a/.github/workflows/stripe.build.yml
+++ b/.github/workflows/stripe.build.yml
@@ -3,24 +3,15 @@ name: Stripe Build Librechat Image
 on:
   # Manual trigger
   workflow_dispatch:
-  
-  # Automatic trigger on new commits to develop branch
+
+  # Automatic trigger on new commits on any branch
   push:
     branches:
-      - develop
-  # Trigger builds for PRs targeting develop branch
-  pull_request:
-    branches:
-      - develop
+      - '**'
+
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - target: node
-            file: Dockerfile
-            image_name: librechat
 
     steps:
       - name: Checkout
@@ -66,11 +57,11 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          file: ${{ matrix.file }}
+          file: Dockerfile
           push: true
           tags: |
             stripe/librechat:${{ github.sha }}
             stripe/librechat:${{ env.SANITIZED_REF_NAME }}-${{ github.sha }}
-            stripe/librechat:latest
-          platforms: linux/amd64,linux/arm64
-          target: ${{ matrix.target }}
+            ${{ github.ref_name == 'develop' && 'stripe/librechat:latest' || '' }}
+          platforms: linux/arm64
+          target: node


### PR DESCRIPTION
This PR:
- Publishes any pushes from any branch to Dockerhub. Primarily done so rebases trigger github actions.
- Only builds for arm64
- Only publishes `stripe/librechat:latest`, when there's commits on develop (intended to be upon merge)