### PR TITLE
Hide artifacts if SANDPACK_BUNDLER_URL is not present

### DIFF
--- a/client/src/components/Chat/Input/ToolsDropdown.tsx
+++ b/client/src/components/Chat/Input/ToolsDropdown.tsx
@@ -269,7 +269,10 @@ const ToolsDropdown = ({ disabled }: ToolsDropdownProps) => {
     });
   }
 
-  if (artifactsEnabled) {
+  // <Stripe> added environment variable check
+  const showArtifacts = artifactsEnabled && !!process.env.SANDPACK_BUNDLER_URL;
+  if (showArtifacts) {
+    // </Stripe>
     dropdownItems.push({
       hideOnClick: false,
       render: (props) => (

--- a/client/src/components/SidePanel/Agents/Artifacts.tsx
+++ b/client/src/components/SidePanel/Agents/Artifacts.tsx
@@ -37,6 +37,12 @@ export default function Artifacts() {
     });
   };
 
+  // <Stripe> added environment variable check
+  if (!process.env.SANDPACK_BUNDLER_URL) {
+    return null;
+  }
+  // </Stripe>
+
   const isEnabled = artifactsMode !== undefined && artifactsMode !== '';
   const isCustomEnabled = artifactsMode === ArtifactModes.CUSTOM;
   const isShadcnEnabled = artifactsMode === ArtifactModes.SHADCNUI;


### PR DESCRIPTION
This PR hides the artifacts pane if `SANDPACK_BUNDLER_URL` isn't present.

We do because we only want to enable artifacts in QA for now and there's no way to parameterize the capabilities settings in librechat.yaml

